### PR TITLE
Add license field to package description.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
 	"name": "libwebp",
 	"description": "D bindings for WebP",
+	"license": "BSD 3-clause",
 	"homepage": "https://github.com/lionello/libwebp",
 	"authors": [
 		"Lionello Lunesu"


### PR DESCRIPTION
I've just noticed that the library is registered on code.dlang.org, but doesn't have any valid branch/tag because a license field is missing. 3-clause BSD seems to be the correct license according to https://code.google.com/p/webm/source/browse/COPYING?repo=libwebp
